### PR TITLE
Add a C# namespace comment provider

### DIFF
--- a/CommentMyCode.cs
+++ b/CommentMyCode.cs
@@ -9,7 +9,6 @@ using MB.VS.Extension.CommentMyCode.MacroExpander;
 using MB.VS.Extension.CommentMyCode.Providers;
 using MB.VS.Extension.CommentMyCode.UserOptions;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.ComponentModel.Design;
 using System.Diagnostics;
@@ -333,8 +332,11 @@ namespace MB.VS.Extension.CommentMyCode
     /// <summary>
     /// Struct object
     /// </summary>
-    Struct =   0x0040
-
+    Struct =   0x0040,
+    /// <summary>
+    /// Namespace object
+    /// </summary>
+    Namespace = 0x0080
   } // end of enum - SupportedCommandTypeFlag
 
 

--- a/CommentMyCode.csproj
+++ b/CommentMyCode.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Providers\csharp\CSharpEnumCommentProvider.cs" />
     <Compile Include="Providers\csharp\CSharpFileCommentProvider.cs" />
     <Compile Include="Providers\csharp\CSharpFunctionCommentProvider.cs" />
+    <Compile Include="Providers\csharp\CSharpNamespaceCommentProvider.cs" />
     <Compile Include="Providers\csharp\CSharpPropertyCommentProvider.cs" />
     <Compile Include="Providers\c\CCommentProvider.cs" />
     <Compile Include="Providers\c\CFunctionCommentProvider.cs" />

--- a/Context/ItemContext.cs
+++ b/Context/ItemContext.cs
@@ -230,6 +230,9 @@ namespace MB.VS.Extension.CommentMyCode.Context
               case vsCMElement.vsCMElementProperty:
                 CommentType = SupportedCommandTypeFlag.Property;
                 break;
+              case vsCMElement.vsCMElementNamespace:
+                CommentType = SupportedCommandTypeFlag.Namespace;
+                break;
               default:
                 CommentType = SupportedCommandTypeFlag.Unknown;
                 break;

--- a/Providers/BaseProvider.cs
+++ b/Providers/BaseProvider.cs
@@ -270,7 +270,6 @@ namespace MB.VS.Extension.CommentMyCode.Providers
     /************************ Construction ***********************************/
     /************************ Methods ****************************************/
     /************************ Fields *****************************************/
-    string[] m_originalLines = null;
     /************************ Static *****************************************/
   } // end of class - BaseCommentProvider
 

--- a/Providers/csharp/CSharpNamespaceCommentProvider.cs
+++ b/Providers/csharp/CSharpNamespaceCommentProvider.cs
@@ -1,23 +1,25 @@
 ﻿/******************************************************************************
- * File...: TextPointExtension.cs
- * Remarks:
+ * File...: CSharpNamespaceCommentProvider.cs
+ * Remarks: ICommentProvider for C# namespace items.
  */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.ComponentModel.Composition;
 
-namespace MB.VS.Extension.CommentMyCode.Extensions
+namespace MB.VS.Extension.CommentMyCode.Providers.csharp
 {
-
-
-  /************************** TextPointExtension *****************************/
+  /************************** CSharpNamespaceCommentProvider *****************/
   /// <summary>
-  /// Provides various extension methods for the <see cref="EnvDTE.TextPoint"/>
-  /// object
+  /// Provides commenting for C# namespaces
   /// </summary>
-  public static class TextPointExtension
+  /// <remarks>
+  /// The <see cref="CSharpCommentProvider.ProcessFooterComments"/> method
+  /// should process the end of namespace as expected. At this point the
+  /// class is only provided to support the namespace command type.
+  /// </remarks>
+  [Export(typeof(ICommentProvider))] // Indicate we implement ICommentProvider
+  [ExportMetadata("SupportedCommandTypes",
+    (int)(SupportedCommandTypeFlag.Namespace))]
+  [ExportMetadata("SupportedExtensions", new string[] { ".cs" })]
+  public class CSharpNamespaceCommentProvider : CSharpCommentProvider
   {
     /*======================= PUBLIC ========================================*/
     /************************ Events *****************************************/
@@ -26,36 +28,6 @@ namespace MB.VS.Extension.CommentMyCode.Extensions
     /************************ Methods ****************************************/
     /************************ Fields *****************************************/
     /************************ Static *****************************************/
-    /*----------------------- GetCodeElement --------------------------------*/
-    /// <summary>
-    /// Gets the <see cref="EnvDTE.CodeElement"/> of the text point
-    /// </summary>
-    /// <param name="tp"></param>
-    /// <returns></returns>
-    public static EnvDTE.CodeElement GetCodeElement(this EnvDTE.TextPoint tp)
-    {
-      var scopes = new List<EnvDTE.vsCMElement>()
-        {
-          EnvDTE.vsCMElement.vsCMElementFunction,
-          EnvDTE.vsCMElement.vsCMElementProperty,
-          EnvDTE.vsCMElement.vsCMElementEnum,
-          EnvDTE.vsCMElement.vsCMElementClass,
-          EnvDTE.vsCMElement.vsCMElementInterface,
-          EnvDTE.vsCMElement.vsCMElementNamespace,
-        };
-      EnvDTE.CodeElement retval = null;
-      foreach(var s in scopes)
-      {
-        try
-        {
-          var scope = (EnvDTE.vsCMElement)s;
-          retval = tp.CodeElement[scope];
-          if (retval != null) break;
-        }
-        catch {; }
-      }
-      return retval;
-    } // end of function - GetCodeElement
 
     /*======================= PROTECTED =====================================*/
     /************************ Events *****************************************/
@@ -72,10 +44,8 @@ namespace MB.VS.Extension.CommentMyCode.Extensions
     /************************ Methods ****************************************/
     /************************ Fields *****************************************/
     /************************ Static *****************************************/
-  } // end of class - CodeElementExtension
 
+  } /* End of Class - CSharpNamespaceCommentProvider */
 
-}
-
-
-/* End CodeElementExtension.cs */
+} /* End of Namespace - MB.VS.Extension.CommentMyCode.Providers.csharp */
+/* End of document - CSharpNamespaceCommentProvider.cs */


### PR DESCRIPTION
The concept of `EnvDTE.vsCMElement.vsCMElementNamespace` was not handled previously. This PR adds the ability to recognize a Namespace element and provides a C# comment provider for usage.